### PR TITLE
Added event name in listener to get it in result function call();

### DIFF
--- a/src/android/com/github/nkzawa/emitter/Emitter.java
+++ b/src/android/com/github/nkzawa/emitter/Emitter.java
@@ -114,7 +114,7 @@ public class Emitter {
         ConcurrentLinkedQueue<Listener> callbacks = this.callbacks.get(event);
         if (callbacks != null) {
             for (Listener fn : callbacks) {
-                fn.call(args);
+                fn.call(event, args);
             }
         }
         return this;
@@ -145,7 +145,7 @@ public class Emitter {
 
     public static interface Listener {
 
-        public void call(Object... args);
+        public void call(String event, Object... args);
     }
 
     private class OnceListener implements Listener {
@@ -161,7 +161,7 @@ public class Emitter {
         @Override
         public void call(Object... args) {
             Emitter.this.off(this.event, this);
-            this.fn.call(args);
+            this.fn.call(this.event, args);
         }
     }
 }


### PR DESCRIPTION
It will be useful if we assign same listener to multiple events.
Recently I used this library in my android project with node.js and raspberry pi + arduino
I used this emitter callback function to get two events temprature and light state data, 

Using previous functions i have to assign two seperate Listner functions for both of them but if we use event name which is also available in emitter class i can solve my problem. Hope you understand this what i want to say. thanks in advance and sorry for my bad english.